### PR TITLE
Deprecate the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,48 @@
 # Symfony UX Stimulus testing
 
+> [!WARNING]
+> **Deprecated**: This package is deprecated and will not receive any further updates.
+
+Because this package only provides very small helpers to help write tests for Stimulus controllers, and is tightly coupled with [Jest](https://jestjs.io/), [jsdom](https://github.com/jsdom/jsdom) and [Testing Library](https://testing-library.com/) dependencies, we can no longer recommend it.
+
+In 2025, we cannot force developers to install Jest (and [~270 sub-dependencies](https://npmgraph.js.org/?q=jest) including [Babel](https://babeljs.io/)) and the like, since [many test runners exist](https://npmtrends.com/ava-vs-japa-vs-jasmine-vs-jest-vs-karma-vs-mocha-vs-tap-vs-vitest), and many of them are more modern and much faster, like [Vitest](https://vitest.dev/).
+
+We want to give you the choice to use the best tools for your needs, and not force you to use what we suggested in the past.
+
+To migrate from `@symfony/stimulus-testing`, you can follow these steps:
+
+1. Install the dev dependencies `@testing-library/jest-dom @testing-library/dom`;
+    you may also want to install `mutationobserver-shim regenerator-runtime` if you still have 
+    legacy code or _architecture_.
+2. In the file `assets/test/setup.js`, replace imports:
+```diff
+-import '@symfony/stimulus-testing/setup';
++import '@testing-library/jest-dom';
+```
+3. Create the file `assets/test/stimulus-helpers.js` with the following content:
+```js
+export function mountDOM(html = '') {
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    document.body.appendChild(div);
+
+    return div;
+}
+
+export function clearDOM() {
+    document.body.innerHTML = '';
+}
+```
+4. In your tests files, replace imports for `mountDOM` and `clearDOM`:
+```diff
+// assets/test/controllers/hello_controller.test.js
+-import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
++import { clearDOM, mountDOM } from '../stimulus-helpers';
+```
+5. And finally, remove the `@symfony/stimulus-testing` dependency from your project.
+
+---
+
 Symfony UX Stimulus testing is a low-level package to help write tests for Stimulus controllers
 in applications and reusable packages.
 


### PR DESCRIPTION
I don't think there is any interest in _maintaining_ it anymore. Because of Jest and Babel, installing `@symfony/stimulus-testing` installs [**~500 subdependencies**](https://npmgraph.js.org/?q=%40symfony%2Fstimulus-testing), which is totally unacceptable, since the added-value of this package is only these two functions:
```js
export function mountDOM(html = '') {
    const div = document.createElement('div');
    div.innerHTML = html;
    document.body.appendChild(div);

    return div;
}

export function clearDOM() {
    document.body.innerHTML = '';
}
```

It's like a Composer package, but all its dependencies being shadowed and not removable by the final user. 

Removing it from @symfony/ux, where we don't use Jest and Babel but Vitest, allowed us to remove ~400 useless Node.js dev dependencies: https://github.com/symfony/ux/pull/2879

The package is still experimental, and I suggest to deprecate this package. I've added migration steps for people being stuck with it, even if I think we, Symfony, are maybe the only ones to use it: 

https://github.com/user-attachments/assets/86a21c37-8560-43dc-bec9-0043875831ea

We can observe:
1. it always had ~1k downloads per week this last year, 
2. more recently we had ~21k downloads per week, and I believe that's correlated to my last two-months work on UX
3. and since a few days, it started to drop again (currently at 8k downloads for the last full week), when I removed it from UX
